### PR TITLE
fix: Allow "extraneous-dependencies" rule in vite and vitest config files

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -7,7 +7,7 @@ import reactRuleSet from '../rules/react.js';
 export default [
   {
     languageOptions: {
-      ...react.configs.flat?.recommended.languageOptions,
+      ...react.configs.recommended.languageOptions,
     },
 
     settings: {

--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -7,7 +7,7 @@ import reactRuleSet from '../rules/react.js';
 export default [
   {
     languageOptions: {
-      ...react.configs.recommended.languageOptions,
+      ...react.configs.flat?.recommended.languageOptions,
     },
 
     settings: {

--- a/packages/eslint-config/rules/imports.js
+++ b/packages/eslint-config/rules/imports.js
@@ -116,6 +116,8 @@ export default {
           '**/eslint-rules/**',
           '**/.storybook/**', // storybook config
           '**/*.{stories,story}.{js,jsx,ts,tsx}', // storybook stories
+          '**/vite.config.*.{js,ts}', // vite config
+          '**/vitest.*.{js,ts}', // vitest config
         ],
         optionalDependencies: false,
       },


### PR DESCRIPTION
## Describe your changes

Vite and Vitest config files were missing from the `import/no-extraneous-dependencies` permission list, so this has been fixed.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
