### PR TITLE
ci: Override the conventional-changelog preset

### DIFF
--- a/packages/release-config/index.js
+++ b/packages/release-config/index.js
@@ -18,6 +18,30 @@ export default {
       '@semantic-release/release-notes-generator',
       {
         preset: 'conventionalcommits',
+
+        // Override the conventional-changelog preset to accommodate the `releaseRules` you added to the `@semantic-release/commit-analyzer` plugin options.
+        // see: https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+        presetConfig: {
+          // origin preset: https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js
+          types: [
+            { type: 'feat', section: 'Features' },
+            { type: 'feature', section: 'Features' },
+            { type: 'fix', section: 'Bug Fixes' },
+            { type: 'perf', section: 'Performance Improvements' },
+            { type: 'revert', section: 'Reverts' },
+
+            // Override the configuration to include `docs` type in the release notes.
+            { type: 'docs', scope: 'README', section: 'Documentation' },
+            { type: 'docs', scope: 'LICENSE', section: 'Documentation' },
+
+            { type: 'style', section: 'Styles', hidden: true },
+            { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
+            { type: 'refactor', section: 'Code Refactoring', hidden: true },
+            { type: 'test', section: 'Tests', hidden: true },
+            { type: 'build', section: 'Build System', hidden: true },
+            { type: 'ci', section: 'Continuous Integration', hidden: true },
+          ],
+        },
       },
     ],
     '@semantic-release/changelog',


### PR DESCRIPTION
## Describe your changes

Override the [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset to accommodate the `releaseRules` added to [the options](https://github.com/wakamsha/frontend-tools/blob/main/packages/release-config/index.js#L11-L14) in `@semantic-release/commit-analyzer` plugin.

### References

- https://github.com/semantic-release/release-notes-generator?tab=readme-ov-file#options
- https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
- https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
