### PR TITLE
ci: checkout PR head in lint and test workflows

### DIFF
--- a/.github/workflows/check_syntax.yml
+++ b/.github/workflows/check_syntax.yml
@@ -3,13 +3,15 @@ name: Check Syntax
 on:
   pull_request_target:
     branches:
-      - "*"
+      - '*'
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Initialize
         uses: ./.github/actions/restore-node

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Initialize
         uses: ./.github/actions/restore-node


### PR DESCRIPTION
## Describe your changes

The `check_syntax.yml` and `run_test.yml` workflows use the `pull_request_target` event. On that event, `actions/checkout` defaults to the base branch ref and evaluates `main` instead of the PR under review, so lint/test results on PRs reflect the state of `main` rather than the incoming changes.

Pin `actions/checkout` to `github.event.pull_request.head.sha` in both workflows so that lint and snapshot tests actually validate the PR code.

This fix needs to land on `main` first because `pull_request_target` always resolves the workflow definition from the base branch; workflow edits inside a feature PR do not take effect until merged.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.