### PR TITLE
feat(eslint-config)!: include vitest all rules in test config

### DIFF
--- a/packages/eslint-config/rules/vitest.js
+++ b/packages/eslint-config/rules/vitest.js
@@ -7,6 +7,9 @@ export default {
   },
 
   rules: {
+    // @ts-ignore
+    ...vitest.configs.all.rules,
+    // @ts-ignore
     ...vitest.configs.recommended.rules,
 
     // Disallow duplicate setup and teardown hooks

--- a/packages/eslint-config/test/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/eslint-config/test/test/__snapshots__/snapshot.test.ts.snap
@@ -2733,14 +2733,50 @@ exports[`ESLint Configuration Snapshot Tests > should match ESLint Configuration
     "vars-on-top": [
       2,
     ],
+    "vitest/consistent-test-filename": [
+      1,
+    ],
+    "vitest/consistent-test-it": [
+      1,
+    ],
     "vitest/expect-expect": [
       2,
+    ],
+    "vitest/max-expects": [
+      1,
+    ],
+    "vitest/max-nested-describe": [
+      1,
+    ],
+    "vitest/no-alias-methods": [
+      1,
     ],
     "vitest/no-commented-out-tests": [
       2,
     ],
+    "vitest/no-conditional-expect": [
+      1,
+    ],
+    "vitest/no-conditional-in-test": [
+      1,
+    ],
+    "vitest/no-conditional-tests": [
+      1,
+    ],
+    "vitest/no-disabled-tests": [
+      1,
+    ],
+    "vitest/no-done-callback": [
+      1,
+    ],
     "vitest/no-duplicate-hooks": [
       2,
+    ],
+    "vitest/no-focused-tests": [
+      1,
+    ],
+    "vitest/no-hooks": [
+      1,
     ],
     "vitest/no-identical-title": [
       2,
@@ -2748,14 +2784,137 @@ exports[`ESLint Configuration Snapshot Tests > should match ESLint Configuration
     "vitest/no-import-node-test": [
       2,
     ],
+    "vitest/no-interpolation-in-snapshots": [
+      1,
+    ],
+    "vitest/no-large-snapshots": [
+      1,
+    ],
+    "vitest/no-mocks-import": [
+      1,
+    ],
+    "vitest/no-restricted-matchers": [
+      1,
+    ],
+    "vitest/no-restricted-vi-methods": [
+      1,
+    ],
+    "vitest/no-standalone-expect": [
+      1,
+    ],
+    "vitest/no-test-prefixes": [
+      1,
+    ],
+    "vitest/no-test-return-statement": [
+      1,
+    ],
+    "vitest/padding-around-after-all-blocks": [
+      1,
+    ],
+    "vitest/padding-around-after-each-blocks": [
+      1,
+    ],
+    "vitest/padding-around-all": [
+      1,
+    ],
+    "vitest/padding-around-before-all-blocks": [
+      1,
+    ],
+    "vitest/padding-around-before-each-blocks": [
+      1,
+    ],
+    "vitest/padding-around-describe-blocks": [
+      1,
+    ],
+    "vitest/padding-around-expect-groups": [
+      1,
+    ],
+    "vitest/padding-around-test-blocks": [
+      1,
+    ],
+    "vitest/prefer-called-with": [
+      1,
+    ],
+    "vitest/prefer-comparison-matcher": [
+      1,
+    ],
+    "vitest/prefer-each": [
+      1,
+    ],
+    "vitest/prefer-equality-matcher": [
+      1,
+    ],
+    "vitest/prefer-expect-assertions": [
+      1,
+    ],
+    "vitest/prefer-expect-resolves": [
+      1,
+    ],
+    "vitest/prefer-hooks-in-order": [
+      1,
+    ],
+    "vitest/prefer-hooks-on-top": [
+      1,
+    ],
+    "vitest/prefer-lowercase-title": [
+      1,
+    ],
+    "vitest/prefer-mock-promise-shorthand": [
+      1,
+    ],
+    "vitest/prefer-snapshot-hint": [
+      1,
+    ],
+    "vitest/prefer-spy-on": [
+      1,
+    ],
+    "vitest/prefer-strict-equal": [
+      1,
+    ],
+    "vitest/prefer-to-be": [
+      1,
+    ],
+    "vitest/prefer-to-be-falsy": [
+      1,
+    ],
+    "vitest/prefer-to-be-object": [
+      1,
+    ],
+    "vitest/prefer-to-be-truthy": [
+      1,
+    ],
+    "vitest/prefer-to-contain": [
+      1,
+    ],
+    "vitest/prefer-to-have-length": [
+      1,
+    ],
+    "vitest/prefer-todo": [
+      1,
+    ],
+    "vitest/prefer-vi-mocked": [
+      1,
+    ],
+    "vitest/require-hook": [
+      1,
+    ],
     "vitest/require-local-test-context-for-concurrent-snapshots": [
       2,
+    ],
+    "vitest/require-to-throw-message": [
+      1,
+    ],
+    "vitest/require-top-level-describe": [
+      1,
     ],
     "vitest/valid-describe-callback": [
       2,
     ],
     "vitest/valid-expect": [
       2,
+    ],
+    "vitest/valid-expect-in-promise": [
+      1,
     ],
     "vitest/valid-title": [
       2,


### PR DESCRIPTION
## Describe your changes

This pull request updates the Vitest rule set in `@wakamsha/eslint-config` test config to correctly include `vitest.configs.all.rules` in addition to `vitest.configs.recommended.rules`.

As a result, the package now provides the expected Vitest lint rule coverage. Snapshot tests were updated accordingly to reflect the expanded rule set.

BREAKING CHANGE: `@wakamsha/eslint-config` test rules now include additional Vitest rules from `vitest.configs.all`, which can introduce new lint findings in consumer projects.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

Product update phrase: Expanded Vitest lint coverage in `@wakamsha/eslint-config` test preset.