### PR TITLE
fix(stylelint-config): align node engine with stylelint v17 requirements

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20.19.0"
   },
   "files": [
     "configs"


### PR DESCRIPTION
## Summary
- update `@wakamsha/stylelint-config` `engines.node` from `>=18.12.0` to `>=20.19.0`
- align declared runtime requirement with installed dependencies (`stylelint@17.12.0` and `stylelint-config-standard@40.0.0`)

## Why
Current dependency versions require Node `>=20.19.0`, so package metadata should match actual runtime constraints to avoid unsupported installations.

## Changes
- `packages/stylelint-config/package.json`
  - `engines.node`: `>=18.12.0` -> `>=20.19.0`
