### PR TITLE
feat(oxlint-config): enable jsdoc tags; `remarks` and `typeParam`

### DIFF
--- a/packages/oxlint-config/rules-json/jsdoc.json
+++ b/packages/oxlint-config/rules-json/jsdoc.json
@@ -2,6 +2,12 @@
   "$schema": "../node_modules/oxlint/configuration_schema.json",
   "plugins": ["jsdoc"],
   "rules": {
+    "jsdoc/check-tag-names": [
+      "error",
+      {
+        "definedTags": ["remarks", "typeParam"]
+      }
+    ],
     "jsdoc/require-param": [
       "error",
       {

--- a/packages/oxlint-config/src/rules/jsdoc.ts
+++ b/packages/oxlint-config/src/rules/jsdoc.ts
@@ -3,6 +3,12 @@ import { defineConfig } from 'oxlint';
 export default defineConfig({
   plugins: ['jsdoc'],
   rules: {
+    'jsdoc/check-tag-names': [
+      'error',
+      {
+        definedTags: ['remarks', 'typeParam'],
+      },
+    ],
     'jsdoc/require-param': [
       'error',
       {


### PR DESCRIPTION
## Describe your changes

Enable the `jsdoc/check-tag-names` rule in the oxlint-config preset and register `remarks` and `typeParam` as additional valid JSDoc tags via `definedTags`. This prevents these commonly used TSDoc tags from being flagged as unknown tag names.

Changes are applied in both the source rule definition ([packages/oxlint-config/src/rules/jsdoc.ts](packages/oxlint-config/src/rules/jsdoc.ts)) and the generated JSON output ([packages/oxlint-config/rules-json/jsdoc.json](packages/oxlint-config/rules-json/jsdoc.json)).

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.