### PR TITLE
fix(oxlint-config): disable `typescript/strict-void-return` and `unicorn/no-nested-ternary`

### DIFF
--- a/packages/oxlint-config/rules-json/typescript.json
+++ b/packages/oxlint-config/rules-json/typescript.json
@@ -46,6 +46,7 @@
             "allowRegExp": false
           }
         ],
+        "typescript/strict-void-return": ["off"],
         "typescript/return-await": ["error", "error-handling-correctness-only"]
       }
     },

--- a/packages/oxlint-config/rules-json/unicorn.json
+++ b/packages/oxlint-config/rules-json/unicorn.json
@@ -18,6 +18,7 @@
     "unicorn/no-array-for-each": ["off"],
     "unicorn/no-array-reduce": ["off"],
     "unicorn/no-negated-condition": ["off"],
+    "unicorn/no-nested-ternary": ["off"],
     "unicorn/no-null": ["off"],
     "unicorn/prefer-global-this": ["off"],
     "unicorn/prefer-import-meta-properties": ["off"],

--- a/packages/oxlint-config/src/rules/typescript.ts
+++ b/packages/oxlint-config/src/rules/typescript.ts
@@ -47,6 +47,7 @@ export default defineConfig({
             allowRegExp: false,
           },
         ],
+        'typescript/strict-void-return': ['off'],
         'typescript/return-await': ['error', 'error-handling-correctness-only'],
       },
     },

--- a/packages/oxlint-config/src/rules/unicorn.ts
+++ b/packages/oxlint-config/src/rules/unicorn.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     'unicorn/no-array-for-each': ['off'],
     'unicorn/no-array-reduce': ['off'],
     'unicorn/no-negated-condition': ['off'],
+    'unicorn/no-nested-ternary': ['off'],
     'unicorn/no-null': ['off'],
     'unicorn/prefer-global-this': ['off'],
     'unicorn/prefer-import-meta-properties': ['off'],

--- a/packages/oxlint-config/test/nextjs/__snapshots__/snapshot.test.ts.snap
+++ b/packages/oxlint-config/test/nextjs/__snapshots__/snapshot.test.ts.snap
@@ -105,6 +105,7 @@ exports[`nextjs > should match oxlint config snapshot 1`] = `
           ],
         ],
         "typescript/strict-boolean-expressions": "warn",
+        "typescript/strict-void-return": "allow",
       },
     },
     {
@@ -701,7 +702,7 @@ exports[`nextjs > should match oxlint config snapshot 1`] = `
     "unicorn/no-magic-array-flat-depth": "deny",
     "unicorn/no-negated-condition": "allow",
     "unicorn/no-negation-in-equality-check": "deny",
-    "unicorn/no-nested-ternary": "deny",
+    "unicorn/no-nested-ternary": "allow",
     "unicorn/no-new-array": "deny",
     "unicorn/no-new-buffer": "deny",
     "unicorn/no-null": "allow",

--- a/packages/oxlint-config/test/node/__snapshots__/snapshot.test.ts.snap
+++ b/packages/oxlint-config/test/node/__snapshots__/snapshot.test.ts.snap
@@ -447,7 +447,7 @@ exports[`node > should match oxlint config snapshot 1`] = `
     "unicorn/no-magic-array-flat-depth": "deny",
     "unicorn/no-negated-condition": "allow",
     "unicorn/no-negation-in-equality-check": "deny",
-    "unicorn/no-nested-ternary": "deny",
+    "unicorn/no-nested-ternary": "allow",
     "unicorn/no-new-array": "deny",
     "unicorn/no-new-buffer": "deny",
     "unicorn/no-null": "allow",

--- a/packages/oxlint-config/test/react/__snapshots__/snapshot.test.ts.snap
+++ b/packages/oxlint-config/test/react/__snapshots__/snapshot.test.ts.snap
@@ -105,6 +105,7 @@ exports[`react > should match oxlint config snapshot 1`] = `
           ],
         ],
         "typescript/strict-boolean-expressions": "warn",
+        "typescript/strict-void-return": "allow",
       },
     },
     {
@@ -666,7 +667,7 @@ exports[`react > should match oxlint config snapshot 1`] = `
     "unicorn/no-magic-array-flat-depth": "deny",
     "unicorn/no-negated-condition": "allow",
     "unicorn/no-negation-in-equality-check": "deny",
-    "unicorn/no-nested-ternary": "deny",
+    "unicorn/no-nested-ternary": "allow",
     "unicorn/no-new-array": "deny",
     "unicorn/no-new-buffer": "deny",
     "unicorn/no-null": "allow",

--- a/packages/oxlint-config/test/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/oxlint-config/test/test/__snapshots__/snapshot.test.ts.snap
@@ -105,6 +105,7 @@ exports[`test > should match oxlint config snapshot 1`] = `
           ],
         ],
         "typescript/strict-boolean-expressions": "warn",
+        "typescript/strict-void-return": "allow",
       },
     },
     {
@@ -562,7 +563,7 @@ exports[`test > should match oxlint config snapshot 1`] = `
     "unicorn/no-magic-array-flat-depth": "deny",
     "unicorn/no-negated-condition": "allow",
     "unicorn/no-negation-in-equality-check": "deny",
-    "unicorn/no-nested-ternary": "deny",
+    "unicorn/no-nested-ternary": "allow",
     "unicorn/no-new-array": "deny",
     "unicorn/no-new-buffer": "deny",
     "unicorn/no-null": "allow",

--- a/packages/oxlint-config/test/typescript/__snapshots__/snapshot.test.ts.snap
+++ b/packages/oxlint-config/test/typescript/__snapshots__/snapshot.test.ts.snap
@@ -105,6 +105,7 @@ exports[`typescript > should match oxlint config snapshot 1`] = `
           ],
         ],
         "typescript/strict-boolean-expressions": "warn",
+        "typescript/strict-void-return": "allow",
       },
     },
     {
@@ -531,7 +532,7 @@ exports[`typescript > should match oxlint config snapshot 1`] = `
     "unicorn/no-magic-array-flat-depth": "deny",
     "unicorn/no-negated-condition": "allow",
     "unicorn/no-negation-in-equality-check": "deny",
-    "unicorn/no-nested-ternary": "deny",
+    "unicorn/no-nested-ternary": "allow",
     "unicorn/no-new-array": "deny",
     "unicorn/no-new-buffer": "deny",
     "unicorn/no-null": "allow",


### PR DESCRIPTION
## Describe your changes

Disable two oxlint rules in `@wakamsha/oxlint-config`:

- `typescript/strict-void-return` — turned off in the TypeScript rule set.
- `unicorn/no-nested-ternary` — turned off in the unicorn rule set.

The corresponding generated `rules-json` files and config snapshot tests were updated accordingly.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
