### PR TITLE
feat(oxlint-config)!: remove JSON subpath exports and fix README preset paths

### DIFF
--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -74,7 +74,9 @@ export default defineConfig({
 ```json
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/@wakamsha/oxlint-config/configs/essentials.json"]
+  "extends": [
+    "./node_modules/@wakamsha/oxlint-config/dist/configs/essentials.json"
+  ]
 }
 ```
 
@@ -84,8 +86,8 @@ If you need TypeScript support:
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "extends": [
-    "./node_modules/@wakamsha/oxlint-config/configs/essentials.json",
-    "./node_modules/@wakamsha/oxlint-config/configs/typescript.json"
+    "./node_modules/@wakamsha/oxlint-config/dist/configs/essentials.json",
+    "./node_modules/@wakamsha/oxlint-config/dist/configs/typescript.json"
   ]
 }
 ```

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -6,9 +6,7 @@
     ".": {
       "types": "./dist/configs/index.d.ts",
       "import": "./dist/configs/index.js"
-    },
-    "./configs/*.json": "./dist/configs/*.json",
-    "./configs/test/*.json": "./dist/configs/test/*.json"
+    }
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Describe your changes

- Remove JSON subpath exports from `@wakamsha/oxlint-config` package exports.
- Fix `.oxlintrc.json` usage examples in `README.md` to point to published `dist/configs/*.json` paths.
- Clarify the actual consumable preset paths for `.oxlintrc.json` users.

## Issue ticket number and link

- N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
  - This is a breaking major update for `.oxlintrc.json` users to align documented and supported preset paths.
